### PR TITLE
fix: preserve tracking progress on unreadable listings

### DIFF
--- a/backend/app/clients/p115.py
+++ b/backend/app/clients/p115.py
@@ -98,12 +98,16 @@ class P115Client:
             console_qrcode=False,
         )
 
-    def _with_open_client(self, action: Any) -> Any:
+    def _with_open_client(self, action: Any, *, retry_transient: bool = False) -> Any:
         client = self._open_client()
         try:
-            return action(client)
-        except Exception as exc:
-            raise P115Error(f"115 Open 请求失败：{_p115_sdk_error_message(exc)}") from exc
+            for attempt in range(2 if retry_transient else 1):
+                try:
+                    return action(client)
+                except Exception as exc:
+                    if attempt == 0 and _is_retryable_open_transport_error(exc):
+                        continue
+                    raise P115Error(f"115 Open 请求失败：{_p115_sdk_error_message(exc)}") from exc
         finally:
             _persist_open_tokens(self.settings, client)
 
@@ -263,7 +267,8 @@ class P115Client:
             result: list[P115File] = []
             while True:
                 payload = self._with_open_client(
-                    lambda client: client.fs_files({"cid": str(cid), "limit": 1000, "offset": offset, "show_dir": 1})
+                    lambda client: client.fs_files({"cid": str(cid), "limit": 1000, "offset": offset, "show_dir": 1}),
+                    retry_transient=True,
                 )
                 data = payload.get("data") if isinstance(payload, dict) else []
                 items = data if isinstance(data, list) else []
@@ -297,7 +302,7 @@ class P115Client:
             normalized = "/" + "/".join(part for part in str(path).replace("\\", "/").split("/") if part)
             if normalized == "/":
                 return "0"
-            payload = self._with_open_client(lambda client: client.fs_info({"path": normalized}))
+            payload = self._with_open_client(lambda client: client.fs_info({"path": normalized}), retry_transient=True)
             data = payload.get("data") if isinstance(payload, dict) else {}
             value = data.get("file_id") or data.get("fid") or data.get("id") if isinstance(data, dict) else ""
             return str(value or "0")
@@ -708,6 +713,20 @@ def _p115_sdk_error_message(exc: Exception | None) -> str:
         return ""
     raw = str(exc).strip()
     return raw if raw and raw != type(exc).__name__ else type(exc).__name__
+
+
+def _is_retryable_open_transport_error(exc: Exception) -> bool:
+    message = _p115_sdk_error_message(exc).casefold()
+    return any(
+        marker in message
+        for marker in (
+            "ssleoferror",
+            "connection reset",
+            "connection aborted",
+            "remote end closed",
+            "temporarily unavailable",
+        )
+    )
 
 
 def _response_data(payload: dict[str, Any], fallback: str, *, root_fallback: bool = False) -> dict[str, Any]:

--- a/backend/app/services/saved_episode_scanner.py
+++ b/backend/app/services/saved_episode_scanner.py
@@ -159,32 +159,22 @@ def refresh_saved_episodes(task_id: int, *, qas: QasClient | None = None) -> dic
         scan_ok = False
         message = f"读取{provider_label}目录失败，保留历史已存进度：{type(exc).__name__}"
 
-    # A successful directory listing is authoritative for the UI. Failed checks
-    # retain the previous high-water mark so a transient API error cannot replay
-    # a library from episode one.
-    effective_last = drive_last if scan_ok else recorded_last
+    # A listing which does not contain recognizable episode filenames cannot
+    # prove that the library was emptied. Keep the stored high-water mark so a
+    # naming change or incomplete provider listing never replays old episodes.
+    effective_last = max(recorded_last, drive_last) if scan_ok else recorded_last
     checked_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
     with db() as conn:
-        if scan_ok:
-            if drive_episodes:
-                placeholders = ",".join("?" for _ in drive_episodes)
-                conn.execute(
-                    f"""
-                    UPDATE tracking_episodes
-                    SET status='pending',saved_at=NULL,updated_at=CURRENT_TIMESTAMP
-                    WHERE task_id=? AND status='saved' AND episode_number NOT IN ({placeholders})
-                    """,
-                    (task_id, *sorted(drive_episodes)),
-                )
-            else:
-                conn.execute(
-                    """
-                    UPDATE tracking_episodes
-                    SET status='pending',saved_at=NULL,updated_at=CURRENT_TIMESTAMP
-                    WHERE task_id=? AND status='saved'
-                    """,
-                    (task_id,),
-                )
+        if scan_ok and drive_episodes:
+            placeholders = ",".join("?" for _ in drive_episodes)
+            conn.execute(
+                f"""
+                UPDATE tracking_episodes
+                SET status='pending',saved_at=NULL,updated_at=CURRENT_TIMESTAMP
+                WHERE task_id=? AND status='saved' AND episode_number NOT IN ({placeholders})
+                """,
+                (task_id, *sorted(drive_episodes)),
+            )
         if scan_ok and drive_episodes:
             conn.executemany(
                 """

--- a/tests/test_openlist_p115_open.py
+++ b/tests/test_openlist_p115_open.py
@@ -89,6 +89,20 @@ class P115OpenClientTests(unittest.TestCase):
         self.assertEqual(result.target_cid, "42")
         sdk.clouddownload_task_add_urls.assert_called_once()
 
+    @patch("app.clients.p115._persist_open_tokens")
+    @patch("p115client.P115OpenClient")
+    def test_directory_read_retries_transient_tls_failure_once(self, open_client, _persist):
+        sdk = open_client.return_value
+        sdk.fs_files.side_effect = [
+            RuntimeError("SSLEOFError: remote end closed"),
+            {"state": True, "count": 1, "data": [{"fid": "100", "pid": "0", "fn": "电影", "fc": "0"}]},
+        ]
+
+        entries = P115Client(self.settings()).list_directory()
+
+        self.assertEqual(["电影"], [entry.name for entry in entries])
+        self.assertEqual(2, sdk.fs_files.call_count)
+
     def test_refreshed_open_tokens_clear_settings_cache(self):
         settings = self.settings()
         client = SimpleNamespace(access_token="new-access", refresh_token="new-refresh")

--- a/tests/test_saved_episode_scanner.py
+++ b/tests/test_saved_episode_scanner.py
@@ -254,6 +254,40 @@ class RefreshSavedEpisodesTests(unittest.TestCase):
             [tuple(row) for row in rows],
         )
 
+    def test_empty_listing_keeps_recorded_progress(self):
+        class Qas:
+            def savepath_detail(_, path):
+                return {
+                    "success": True,
+                    "data": {
+                        "paths": [{"name": "strm"}, {"name": "tv"}, {"name": "Show (2024)"}],
+                        "list": [{"file_name": "unparseable-name.mkv", "dir": False}],
+                    },
+                }
+
+        with db() as conn:
+            task_id = conn.execute(
+                """
+                INSERT INTO tracking_tasks(tmdb_id,media_type,title,season_number,provider,save_path,last_saved_episode)
+                VALUES(1,'tv','Show',1,'p115','/strm/tv/Show (2024)',184)
+                """
+            ).lastrowid
+            conn.execute(
+                "INSERT INTO tracking_episodes(task_id,season_number,episode_number,status,provider) VALUES(?,1,184,'saved','p115')",
+                (task_id,),
+            )
+
+        result = refresh_saved_episodes(task_id, qas=Qas())
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(184, result["last_saved_episode"])
+        with db() as conn:
+            row = conn.execute(
+                "SELECT status FROM tracking_episodes WHERE task_id=? AND episode_number=184",
+                (task_id,),
+            ).fetchone()
+        self.assertEqual("saved", row["status"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
修复 115/OpenList 目录可读但文件名未被识别时，智能追更回退并重扫历史集数的问题。保留已记录进度，下一次巡检继续按 TMDB 下一集日期执行。