### PR TITLE
fix: polish tracking path picker

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -137,7 +137,7 @@ function Shell({
   const nav = [
     ["discover", "发现"],
     ["tracking", "智能追更"],
-    ["wishlist", "巡检"],
+    ["wishlist", "愿望单"],
     ["review", "待确认"],
     ["settings", "设置"],
   ] as const;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1703,7 +1703,7 @@ nav button.active {
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 0 5px 0 10px;
+  padding: 0 4px 0 10px;
   border: 1px solid var(--line);
   border-radius: 10px;
   background: var(--surface);
@@ -1719,9 +1719,24 @@ nav button.active {
 }
 
 .tracking-path-picker {
-  width: 28px;
-  min-width: 28px;
-  height: 28px;
+  width: 34px;
+  min-width: 34px;
+  height: 34px;
+  margin-left: 2px;
+  padding: 0;
+  border-radius: 50%;
+  background: var(--surface-2);
+  color: var(--muted);
+}
+
+.tracking-path-picker:hover {
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+  color: var(--accent);
+}
+
+.tracking-path-picker:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .tracking-provider-toggle.active {


### PR DESCRIPTION
- 优化智能追更卡片中的保存路径文件夹按钮，统一尺寸、圆形样式、图标居中及悬停/禁用状态。\n- 恢复顶部主导航的‘愿望单’名称；‘巡检’仅用于设置页。\n\n并入现有 0.5.10 发布线，不升级版本号。已通过前端 pnpm build。