### PR TITLE
fix: disable unsupported 115 to quark manual sync

### DIFF
--- a/frontend/src/features/openlist/OpenListManualSync.tsx
+++ b/frontend/src/features/openlist/OpenListManualSync.tsx
@@ -4,7 +4,7 @@ import { api, ApiError, OpenListEntry } from "../../lib/api";
 
 type OpenListSortKey = "name" | "type" | "time";
 type OpenListSortState = { key: OpenListSortKey; direction: "asc" | "desc" };
-export function OpenListManualSync({ qasPath, p115Path, enabled, copyDisabled = false, copyDisabledReason = "" }: { qasPath: string; p115Path: string; enabled: boolean; copyDisabled?: boolean; copyDisabledReason?: string }) {
+export function OpenListManualSync({ qasPath, p115Path, enabled, copyDisabled = false, copyDisabledReason = "", reverseCopyDisabled = false, reverseCopyDisabledReason = "" }: { qasPath: string; p115Path: string; enabled: boolean; copyDisabled?: boolean; copyDisabledReason?: string; reverseCopyDisabled?: boolean; reverseCopyDisabledReason?: string }) {
   const [leftPath, setLeftPath] = useState(qasPath || "/");
   const [rightPath, setRightPath] = useState(p115Path || "/");
   const [leftEntries, setLeftEntries] = useState<OpenListEntry[]>([]);
@@ -70,6 +70,10 @@ export function OpenListManualSync({ qasPath, p115Path, enabled, copyDisabled = 
   async function copy(direction: "left-to-right" | "right-to-left") {
     if (copyDisabled) {
       setMessage(copyDisabledReason || "手动复制暂时停用");
+      return;
+    }
+    if (direction === "right-to-left" && reverseCopyDisabled) {
+      setMessage(reverseCopyDisabledReason || "从 115 复制到夸克暂时停用");
       return;
     }
     const sourcePath = direction === "left-to-right" ? leftPath : rightPath;
@@ -157,11 +161,12 @@ export function OpenListManualSync({ qasPath, p115Path, enabled, copyDisabled = 
         <label><input type="radio" checked={overwrite} onChange={() => setOverwrite(true)} />覆盖已存在</label>
       </div>
       {copyDisabled && <p className="settings-help">{copyDisabledReason}</p>}
+      {reverseCopyDisabled && <p className="settings-help">{reverseCopyDisabledReason || "当前暂不支持从 115 复制到夸克。"}</p>}
       <div className="openlist-sync-columns">
         {column("夸克媒体库", leftPath, leftEntries, leftSelected, setLeftSelected, "left")}
         <div className="openlist-sync-arrows" aria-label="复制方向">
           <button type="button" className="primary icon" title={copyDisabled ? copyDisabledReason : "从夸克复制到 115"} onClick={() => void copy("left-to-right")} disabled={!enabled || busy || copyDisabled}>→</button>
-          <button type="button" className="primary icon" title={copyDisabled ? copyDisabledReason : "从 115 复制到夸克"} onClick={() => void copy("right-to-left")} disabled={!enabled || busy || copyDisabled}>←</button>
+          <button type="button" className="primary icon" title={reverseCopyDisabled ? reverseCopyDisabledReason || "从 115 复制到夸克暂时停用" : copyDisabled ? copyDisabledReason : "从 115 复制到夸克"} onClick={() => void copy("right-to-left")} disabled={!enabled || busy || copyDisabled || reverseCopyDisabled}>←</button>
         </div>
         {column("115 媒体库", rightPath, rightEntries, rightSelected, setRightSelected, "right")}
       </div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3738,7 +3738,7 @@ function SettingsPage({ section }: { section: Exclude<SettingsTab, "notification
             <p className="settings-help">“立即同步媒体库”固定从夸克媒体库补齐到 115；双向或反向的按文件手动复制请使用“手动同步”页签。</p>
           </SettingsSection>
           )}
-          {openListTab === "manual" && <OpenListManualSync qasPath={form.openlist_qas_library_path || config.openlist_qas_library_path} p115Path={form.openlist_p115_library_path || config.openlist_p115_library_path} enabled={config.openlist_enabled && config.has_openlist_token} />}
+          {openListTab === "manual" && <OpenListManualSync qasPath={form.openlist_qas_library_path || config.openlist_qas_library_path} p115Path={form.openlist_p115_library_path || config.openlist_p115_library_path} enabled={config.openlist_enabled && config.has_openlist_token} reverseCopyDisabled reverseCopyDisabledReason="当前暂不支持从 115 复制到夸克。" />}
           {openListTab === "auto" && (
             <SettingsSection title="追更自动补齐" body="智能追更发现某一集只存在一个网盘时，只复制这一集到缺失网盘，不进行全量同步。">
               <SettingsToggle label="允许自动同步" help="开启后，MediaIndex 会在双网盘转存完成、智能追更转存完成后自动对比两边目录，缺哪边就从另一边复制过去。" value={form.openlist_auto_sync === undefined ? config.openlist_auto_sync : form.openlist_auto_sync === "true"} onChange={(value) => update("openlist_auto_sync", String(value))} trueLabel="允许" falseLabel="关闭" />


### PR DESCRIPTION
修复 OpenList 手动同步界面：115 → 夸克的复制能力当前不可执行，因此禁用对应箭头并显示说明；夸克 → 115 保持可用。\n\n本次不修改版本号、不创建新 Release。\n\n验证：pnpm build 通过。