### PR TITLE
fix: allow PanSou settings override Compose default

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -205,6 +205,16 @@ def normalize_category_path(value: str) -> str:
 
 @lru_cache
 def get_settings() -> Settings:
-    s = Settings(_env_file=os.getenv("MEDIA_CONFIG_PATH", ".env"))
+    config_path = Path(os.getenv("MEDIA_CONFIG_PATH", ".env"))
+    s = Settings(_env_file=config_path)
+    # PANSOU_URL is provided as a Compose default, but the settings page
+    # persists the user override in the runtime env file. Pydantic settings
+    # normally give process environment variables precedence over that file,
+    # which made a Compose default impossible to replace from the UI.
+    if config_path.is_file():
+        for line in config_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if line.startswith("PANSOU_URL="):
+                s.pansou_url = line.split("=", 1)[1].strip()
+                break
     s.ensure_data_dir()
     return s

--- a/tests/test_pansou_normalization.py
+++ b/tests/test_pansou_normalization.py
@@ -1,5 +1,7 @@
 import os
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from app.clients.pansou import (
@@ -9,6 +11,7 @@ from app.clients.pansou import (
     enabled_pansou_cloud_types,
     normalize_pansou_results,
 )
+from app.api.config import ConfigUpdate, update_config
 from app.core.config import get_settings
 
 
@@ -116,6 +119,25 @@ class PansouNormalizationTests(unittest.TestCase):
             with patch.object(client, "_search_native_get", return_value=({"data": {"results": []}}, "")) as native:
                 client.search_detailed("测试")
             self.assertEqual(["quark", "115"], native.call_args.args[1]["cloud_types"])
+        get_settings.cache_clear()
+
+    def test_saved_pansou_url_overrides_compose_environment(self):
+        with TemporaryDirectory() as directory:
+            config_path = Path(directory) / "runtime.env"
+            with patch.dict(
+                os.environ,
+                {
+                    "MEDIA_CONFIG_PATH": str(config_path),
+                    "PANSOU_URL": "http://compose-pansou:8888",
+                    "DB_PATH": str(Path(directory) / "media_index.db"),
+                },
+            ):
+                get_settings.cache_clear()
+                with patch("app.api.config.stop_scheduler"), patch("app.api.config.start_scheduler"):
+                    update_config(ConfigUpdate(pansou_url="http://saved-pansou:8888"))
+                self.assertIn("PANSOU_URL=http://saved-pansou:8888", config_path.read_text(encoding="utf-8"))
+                get_settings.cache_clear()
+                self.assertEqual("http://saved-pansou:8888", get_settings().pansou_url)
         get_settings.cache_clear()
 
 


### PR DESCRIPTION
## What changed
- Make the saved PANSOU_URL in the runtime config file override the Compose-provided default.
- Add a regression test covering settings-page persistence and reload behavior.

## Why
Pydantic gave the process environment precedence over the runtime .env, so a Compose PANSOU_URL could not be replaced from the settings page.

## Validation
- python -m pytest tests/test_pansou_normalization.py -q
- 8 passed

Version number is unchanged.