### PR TITLE
Review ambiguous TV resource titles before tracking

### DIFF
--- a/backend/app/services/link_resolver.py
+++ b/backend/app/services/link_resolver.py
@@ -8,7 +8,7 @@ from app.clients.pansou import infer_share_provider
 from app.clients.qas import QasClient
 from app.core.config import get_settings
 from app.domain.media import LinkResolution, MediaTarget, ResourceCandidate
-from app.services.candidate_ranker import rank_resource_candidates, resource_candidate_sort_key
+from app.services.candidate_ranker import compact, rank_resource_candidates, resource_candidate_sort_key
 from app.services.episode_matcher import build_rename_pair, match_episode_files
 from app.services.query_planner import build_search_queries
 from app.services.share_inspector import ShareInspection, inspect_share
@@ -140,6 +140,7 @@ def resolve_episode_source(
     reviewed: list[ResourceCandidate] = []
     best_review: tuple[int, LinkResolution] | None = None
     valid_but_not_updated = False
+    title_identity_requires_review = False
     external_provider_requires_confirmation = False
 
     for candidate in viable[:max_verify]:
@@ -182,6 +183,20 @@ def resolve_episode_source(
         sequence_based = any("numeric_episode_sequence" in match.reasons for match in matches)
         candidate_title_strong = "title_exact_or_contained" in candidate.reasons
         if sequence_based and not candidate_title_strong:
+            continue
+        if (
+            target.media_type == "tv"
+            and not candidate_title_strong
+            and not _matched_files_confirm_title(target, matches)
+        ):
+            title_identity_requires_review = True
+            reviewed.append(
+                replace(
+                    enriched,
+                    rejected=True,
+                    reasons=(*enriched.reasons, "title_identity_missing"),
+                )
+            )
             continue
         reviewed.append(enriched)
         if matches and coverage >= 1 and all(match.confidence == "high" for match in matches) and (not sequence_based or candidate_title_strong):
@@ -236,6 +251,14 @@ def resolve_episode_source(
             reviewed_candidates=tuple(reviewed),
             errors=tuple(errors),
         )
+    if title_identity_requires_review:
+        return LinkResolution(
+            False,
+            "needs_review",
+            "候选资源的集数可以匹配，但无法确认资源标题，请人工核对后再转存",
+            reviewed_candidates=tuple(reviewed),
+            errors=tuple(errors),
+        )
     if valid_but_not_updated:
         return LinkResolution(
             False,
@@ -260,6 +283,20 @@ def _select_inspection_files(inspection: ShareInspection, selected_names: set[st
     if not files:
         return ShareInspection(False, inspection.share_url, error="selected_files_not_found")
     return replace(inspection, files=files)
+
+
+def _matched_files_confirm_title(target: MediaTarget, matches) -> bool:
+    aliases = tuple(
+        compact(title)
+        for title in target.search_titles
+        if compact(title) and not compact(title).isdigit()
+    )
+    if not aliases:
+        return False
+    return any(
+        any(alias in compact(match.source.name) for alias in aliases)
+        for match in matches
+    )
 
 
 def _progress(callback: Callable[[str, str], None] | None, stage: str, message: str) -> None:

--- a/tests/test_link_resolver.py
+++ b/tests/test_link_resolver.py
@@ -268,6 +268,36 @@ class LinkResolverTests(unittest.TestCase):
         self.assertTrue(strong.ok)
         self.assertEqual("01 1080p.mp4", strong.rename_pairs[0].source_name)
 
+    def test_tv_candidate_with_different_title_is_not_auto_run(self):
+        episodes = tuple(
+            EpisodeTarget(1, number, match_tokens=(f"S01E{number:02d}", f"E{number:02d}"))
+            for number in range(1, 17)
+        )
+        target = MediaTarget(1, "tv", "早九门", season_number=1, episodes=episodes)
+        link = "https://pan.quark.cn/s/wrong-title"
+        qas = FakeQas(
+            {
+                link: share(
+                    *((f"老九门.S01E{number:02d}.mkv", 1) for number in range(1, 41))
+                )
+            }
+        )
+        result = resolve_episode_source(
+            target,
+            qas=qas,
+            pansou=FakePansou(
+                [{"share_url": link, "title": "老九门 第1季 更新至40集"}]
+            ),
+            max_queries=1,
+        )
+
+        self.assertFalse(result.ok)
+        self.assertEqual("needs_review", result.stage)
+        self.assertEqual((), result.rename_pairs)
+        self.assertIn("人工核对", result.message)
+        self.assertIn("title_identity_missing", result.reviewed_candidates[0].reasons)
+        self.assertTrue(result.reviewed_candidates[0].rejected)
+
     def test_115_candidate_is_kept_for_review_but_never_sent_to_qas(self):
         qas = FakeQas({})
         result = resolve_episode_source(


### PR DESCRIPTION
## What changed
- Return `needs_review` when TV episode numbers match but neither the PanSou title nor matched share filenames confirm the target title.
- Preserve the candidate for manual confirmation instead of treating it as no resource.
- Add a regression test for `早九门` incorrectly matching a 40-episode `老九门` share.

## Validation
- `pytest tests/test_link_resolver.py tests/test_query_and_candidates.py -q` (35 passed)

No version number was changed.