### PR TITLE
docs: configure PanSou from the management panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Emby 删除 Webhook → MediaIndex 删除同步（已启用且已确认时）
 
 ## 快速部署
 
-仓库根目录提供可直接运行的 [`docker-compose.yaml`](docker-compose.yaml)。默认只启动 MediaIndex；PanSou 是可选的注释服务，可按需启用。
+仓库根目录提供可直接运行的 [`docker-compose.yaml`](docker-compose.yaml)。默认只启动 MediaIndex；PanSou 是可选的注释服务，可按需启用。PanSou 地址始终在管理面板保存，不需要写入 Compose 环境变量。
 
 ```bash
 mkdir media-index

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,9 +12,7 @@ services:
       # 启动前请修改用户名和密码，应用会拒绝空密码以及密码 admin。
       MEDIA_USER: admin
       MEDIA_PASS: change-this-password
-      # 下方是同一 Compose 中 PanSou 的默认容器地址。
-      PANSOU_URL: http://pansou:8888
-      # 其他设置在网页设置页面填写，并自动保存到 ./data/.env。
+      # PanSou 地址及其他设置在网页设置页面填写，并自动保存到 ./data/.env。
       MEDIA_CONFIG_PATH: /app/data/.env
       STATIC_DIR: /app/frontend
       DB_PATH: /app/data/media_index.db
@@ -29,11 +27,10 @@ services:
       - ./downloads:/downloads
       # 将 NAS 中供 Emby 扫描的 STRM 目录挂载到容器 /strm。
       - ./strm:/strm
-    networks:
-      - media-index-stack
     restart: unless-stopped
 
-  # 可选：PanSou 搜索服务。首次使用时删除下方整段的“# ”即可启用。
+  # 可选：PanSou 搜索服务。首次使用时删除本服务和文末 pansou-cache 定义的“# ”即可启用。
+  # 启用后，在 MediaIndex 管理面板填写 PanSou 地址：http://pansou:8888
   # pansou:
   #   image: ghcr.io/fish2018/pansou:latest
   #   pull_policy: always
@@ -47,13 +44,8 @@ services:
   #     CACHE_TTL: 60
   #   volumes:
   #     - pansou-cache:/app/cache
-  #   networks:
-  #     - media-index-stack
   #   restart: unless-stopped
 
-volumes:
-  pansou-cache:
-
-networks:
-  media-index-stack:
-    name: media-index-stack
+# 可选 PanSou 缓存卷；启用上方 pansou 服务时一并取消注释。
+# volumes:
+#   pansou-cache:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -19,7 +19,7 @@ MediaIndex 是面向个人 NAS 的网盘媒体转存入口与维护中心。它�
 
 将 Emby 扫描的 STRM 目录挂载到容器 `/strm`，例如 `- /volume1/Media/Strm:/strm`。宿主机播放端口不是 8097 时，请在 **STRM 与 302 → STRM 通用设置** 中填写完整的 STRM 播放地址（内网 `http://NAS_IP:8097` 或对外反代域名）。该地址不能填写管理端口 `8000`，容器无需配置 `EMBY_PROXY_PORT`。
 
-如果 PanSou 或 OpenList 不在同一 Docker 网络里，请填写 MediaIndex 容器内可访问的地址，不要填写容器自己的 `127.0.0.1`。
+PanSou 地址由管理面板保存，不需要 `PANSOU_URL` 环境变量。如果 PanSou 或 OpenList 不在同一 Docker 网络里，请填写 MediaIndex 容器内可访问的地址，不要填写容器自己的 `127.0.0.1`。
 
 ### 1.1.1 升级到 0.6.0
 
@@ -38,11 +38,12 @@ volumes:
 
 ### 1.2 一套 Compose 部署 MediaIndex 和 PanSou
 
-仓库的 `docker-compose.yaml` 已预留 PanSou 服务，默认被注释。
+仓库的 `docker-compose.yaml` 已预留 PanSou 服务和缓存卷，默认均被注释。
 
 1. 删除 `pansou` 服务整段每行开头的 `# `。
-2. 修改 MediaIndex 的 `MEDIA_PASS`。
-3. 执行：
+2. 删除文末 `volumes` 中 `pansou-cache` 定义每行开头的 `# `。
+3. 修改 MediaIndex 的 `MEDIA_PASS`。
+4. 执行：
 
    ```bash
    docker compose up -d
@@ -56,7 +57,7 @@ volumes:
    | STRM/302 | `http://NAS_IP:8097` | 同一 MediaIndex 容器的播放入口；端口可在 Compose 左侧调整 |
    | PanSou | `http://NAS_IP:8888` | 资源搜索 API |
 
-同套 Compose 内，MediaIndex 默认访问 `http://pansou:8888`，一般不用改成 NAS IP。
+同套 Compose 启用 PanSou 后，使用浏览器进入 MediaIndex 管理面板，把 PanSou 地址填为 `http://pansou:8888`；不需要重新编辑 Compose 或重建容器。默认 Compose 网络已是项目隔离的 bridge 网络，两个服务会自动互通。
 
 ## 2. 首次配置
 

--- a/tests/test_container_build.py
+++ b/tests/test_container_build.py
@@ -55,6 +55,7 @@ class ContainerBuildTests(unittest.TestCase):
             self.assertIn('- "8000:8000"', compose)
             self.assertIn('- "8097:8097"', compose)
             self.assertIn('MEDIA_PLAYBACK_INTERNAL_PORT: 8097', compose)
+            self.assertNotIn('PANSOU_URL:', compose)
             self.assertNotIn('EMBY_PROXY_PORT:', compose)
             self.assertNotIn('EMBY_PROXY_PORT_LOCKED:', compose)
 


### PR DESCRIPTION
- 标准 Compose 移除 PANSOU_URL 与未使用的自定义 network。\n- 保留注释的 PanSou 服务及缓存卷示例。\n- 通过管理面板保存 PanSou 地址，不必重建容器。\n\n验证：Compose YAML 语法通过；	ests/test_container_build.py tests/test_pansou_normalization.py 20 passed。