### PR TITLE
fix: restore STRM after OpenList copies

### DIFF
--- a/backend/app/api/openlist.py
+++ b/backend/app/api/openlist.py
@@ -79,6 +79,18 @@ def openlist_copy_tasks():
     }
 
 
+@router.post("/tasks/clear-finished")
+def clear_finished_openlist_copy_tasks():
+    settings = get_settings()
+    if not settings.openlist_enabled or not settings.openlist_token.strip():
+        raise HTTPException(status_code=409, detail="OpenList 未启用或 Token 未配置")
+    try:
+        OpenListClient().clear_finished_copy_tasks()
+    except OpenListError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return {"ok": True, "message": "已从 OpenList 清除完成、失败和已取消的复制任务"}
+
+
 @router.post("/sync")
 def sync_openlist(payload: OpenListSyncRequest):
     settings = get_settings()

--- a/backend/app/clients/openlist.py
+++ b/backend/app/clients/openlist.py
@@ -181,6 +181,10 @@ class OpenListClient:
                 })
         return tasks
 
+    def clear_finished_copy_tasks(self) -> None:
+        """Remove completed, failed, and canceled copy tasks from OpenList's queue."""
+        self._post("/api/task/copy/clear_done", {})
+
     def list_entries(self, path: str) -> list[dict]:
         entries = []
         for item in self._items(self.list_directory(path)):

--- a/backend/app/services/openlist_sync.py
+++ b/backend/app/services/openlist_sync.py
@@ -331,6 +331,36 @@ def _run_transfer_output_sync_job(
         message = errors[0]
         _finish_openlist_sync_job(job_id, "failed", "openlist_sync_failed", message)
         return {"ok": False, "job_id": job_id, "message": message}
+    if target_provider == "p115" and result.get("target_dir") and (copied or skipped):
+        submitted = f"OpenList 已提交 {copied} 个文件，目标已有 {skipped} 个；正在等待 115 精确落盘确认"
+        _update_openlist_sync_job(job_id, "openlist_copy_waiting", submitted)
+        update_media_workflow_step(job_id, "transfer", "done", submitted)
+        update_media_workflow_step(job_id, "landing_confirm", "running", "正在通过原生 115 核验 OpenList 复制结果")
+        try:
+            save_path, target_files = _wait_for_openlist_p115_landing(
+                str(result["target_dir"]), filenames, settings=get_settings()
+            )
+        except OpenListError as exc:
+            message = str(exc)
+            update_media_workflow_step(job_id, "landing_confirm", "failed", message)
+            _finish_openlist_sync_job(job_id, "failed", "openlist_landing_failed", message)
+            return {"ok": False, "job_id": job_id, "message": message, "copied": copied, "skipped": skipped}
+        landed_message = f"115 已精确确认 {len(target_files)} 个媒体文件落盘"
+        update_media_workflow_step(job_id, "landing_confirm", "done", landed_message)
+        if not run_post_transfer_pipeline(
+            job_id,
+            provider="p115",
+            title=_openlist_job_title(job_id, str(result["target_dir"])),
+            openlist_message=landed_message,
+            target_path=save_path,
+            target_files=target_files,
+        ):
+            message = f"{landed_message}；后续 STRM 或 Emby 流程未完成，请查看任务链路"
+            _finish_openlist_sync_job(job_id, "failed", "openlist_post_processing_failed", message)
+            return {"ok": False, "job_id": job_id, "message": message, "copied": copied, "skipped": skipped}
+        message = f"{landed_message}；{_openlist_post_processing_summary(job_id)}"
+        _finish_openlist_sync_job(job_id, "done", "openlist_post_processing_done", message)
+        return {"ok": True, "job_id": job_id, "message": message, "copied": copied, "skipped": skipped, "landed": len(target_files)}
     parts = []
     if copied:
         parts.append(f"已向 OpenList 提交 {copied} 个文件的复制任务")

--- a/backend/app/services/openlist_sync.py
+++ b/backend/app/services/openlist_sync.py
@@ -331,14 +331,16 @@ def _run_transfer_output_sync_job(
         message = errors[0]
         _finish_openlist_sync_job(job_id, "failed", "openlist_sync_failed", message)
         return {"ok": False, "job_id": job_id, "message": message}
-    if target_provider == "p115" and result.get("target_dir") and (copied or skipped):
+    settings = get_settings()
+    native_p115_available = organizer_provider(settings, "p115").configured()
+    if target_provider == "p115" and native_p115_available and result.get("target_dir") and (copied or skipped):
         submitted = f"OpenList 已提交 {copied} 个文件，目标已有 {skipped} 个；正在等待 115 精确落盘确认"
         _update_openlist_sync_job(job_id, "openlist_copy_waiting", submitted)
         update_media_workflow_step(job_id, "transfer", "done", submitted)
         update_media_workflow_step(job_id, "landing_confirm", "running", "正在通过原生 115 核验 OpenList 复制结果")
         try:
             save_path, target_files = _wait_for_openlist_p115_landing(
-                str(result["target_dir"]), filenames, settings=get_settings()
+                str(result["target_dir"]), filenames, settings=settings
             )
         except OpenListError as exc:
             message = str(exc)

--- a/backend/app/services/strm_reconciler.py
+++ b/backend/app/services/strm_reconciler.py
@@ -443,6 +443,13 @@ def _content_version(asset: dict[str, Any], content: str) -> str:
 
 def _mark_entry(asset_id: int, root_id: str, relative_path: str, version: str, status: str, error: str, *, written: bool = False, verified: bool = False) -> None:
     with db() as conn:
+        # Removed mappings retain audit rows, but may not block a replacement
+        # asset from legitimately reusing the same library path.
+        conn.execute(
+            """DELETE FROM strm_entries
+               WHERE library_root_id=? AND relative_path=? AND asset_id<>? AND status='removed'""",
+            (root_id, relative_path, asset_id),
+        )
         conn.execute(
             """
             INSERT INTO strm_entries(asset_id,library_root_id,relative_path,content_version,status,last_error_safe,last_written_at,last_verified_at)

--- a/frontend/src/features/activity/ActivityCenter.tsx
+++ b/frontend/src/features/activity/ActivityCenter.tsx
@@ -266,16 +266,30 @@ export function ActivityCenter({ onNavigate }: { onNavigate: (route: AppRoute) =
     onNavigate({ page: "cross-cloud" });
   }
 
-  function clearLogs() {
+  async function clearLogs() {
     const next = Date.now();
     const latestJobId = jobs.reduce((highest, job) => Math.max(highest, job.id), 0);
+    const hasFinishedOpenListTasks = openListTasks.some((task) => task.state !== "running");
+    let openListClearWarning = "";
+    if (hasFinishedOpenListTasks) {
+      try {
+        await api.clearFinishedOpenListTasks();
+        setOpenListTasks((current) => current.filter((task) => task.state === "running"));
+      } catch (error) {
+        openListClearWarning = error instanceof Error ? error.message : "OpenList 复制任务清除失败";
+      }
+    }
     try {
       window.localStorage.setItem(ACTIVITY_CLEARED_BEFORE_KEY, String(next));
       window.localStorage.setItem(ACTIVITY_CLEARED_JOB_ID_KEY, String(latestJobId));
     } catch { /* Browser storage is optional. */ }
     setClearedBefore(next);
     setClearedJobId(latestJobId);
-    setMessage("已清空当前浏览器中的历史日志显示，后台任务记录仍保留");
+    setMessage(openListClearWarning
+      ? `已清空当前浏览器中的历史日志显示；但 ${openListClearWarning}`
+      : hasFinishedOpenListTasks
+        ? "已清空当前浏览器中的历史日志显示，并从 OpenList 清除已结束的复制任务"
+        : "已清空当前浏览器中的历史日志显示，后台任务记录仍保留");
   }
 
   async function exportLogs() {
@@ -372,7 +386,7 @@ export function ActivityCenter({ onNavigate }: { onNavigate: (route: AppRoute) =
                 <button className="ghost compact-action" onClick={() => void load()}><ArrowClockwise size={17} />刷新</button>
                 <button className="ghost compact-action" onClick={() => void exportLogs()} disabled={exporting}>{exporting ? <Spinner /> : <DownloadSimple size={17} />}导出日志</button>
                 <button className="ghost compact-action" onClick={() => void exportDiagnostics()} disabled={exportingDiagnostics} title="导出供开发排障使用的详细时间线，不改变当前用户日志"><DownloadSimple size={17} />{exportingDiagnostics ? "正在打包" : "导出后台诊断包"}</button>
-                <button className="ghost compact-action" onClick={clearLogs} disabled={!clearableCount} title="仅清空当前浏览器中的历史日志显示，后台任务记录会保留"><Trash size={17} />清空日志</button>
+                <button className="ghost compact-action" onClick={() => void clearLogs()} disabled={!clearableCount} title="清空当前浏览器中的历史日志显示；OpenList 已结束的复制任务也会从其队列清除"><Trash size={17} />清空日志</button>
                 <button className="ghost compact-action danger-action" onClick={() => void stopAll()} disabled={!stoppableCount || stopping}>{stopping ? <Spinner /> : <Pause size={17} />}全部停止</button>
                 <button className="ghost compact-action activity-dialog-close" onClick={() => setOpen(false)} title="关闭运行日志" aria-label="关闭运行日志"><X size={18} />关闭</button>
               </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -812,6 +812,7 @@ export const api = {
   syncChannelSources: (channelId = "") => request<{ ok: boolean; message: string; results: Array<{ channel_id: string; ok: boolean; message: string; posts: number; resources: number }> }>(`/api/cloud/channels/sync${channelId ? `?channel_id=${encodeURIComponent(channelId)}` : ""}`, { method: "POST" }),
   testOpenList: () => request<{ ok: boolean; message: string }>("/api/openlist/test", { method: "POST" }),
   openListTasks: () => request<{ available: boolean; message: string; tasks: OpenListCopyTask[] }>("/api/openlist/tasks"),
+  clearFinishedOpenListTasks: () => request<{ ok: boolean; message: string }>("/api/openlist/tasks/clear-finished", { method: "POST" }),
   browseOpenList: (path: string) =>
     request<{ ok: boolean; path: string; directories: { name: string; is_dir: boolean }[] }>("/api/openlist/browse", {
       method: "POST",

--- a/tests/test_openlist_sync.py
+++ b/tests/test_openlist_sync.py
@@ -339,10 +339,12 @@ class OpenListSyncTests(unittest.TestCase):
             get_settings.cache_clear()
             with (
                 patch("app.services.openlist_sync.sync_tracking_files", return_value={"ok": True, "copied": 1, "skipped": 0, "target_dir": "/115/Movie"}),
+                patch("app.services.openlist_sync.organizer_provider") as organizer,
                 patch("app.services.openlist_sync._wait_for_openlist_p115_landing", return_value=("/media/Movie", landed)) as wait_for_landing,
                 patch("app.services.openlist_sync.run_post_transfer_pipeline", return_value=True) as pipeline,
                 patch("app.services.openlist_sync._openlist_post_processing_summary", return_value="STRM 已生成"),
             ):
+                organizer.return_value.configured.return_value = True
                 result = sync_transfer_outputs("qas", "/strm/Movie", ["Movie.mkv"], display_title="Movie")
 
         self.assertTrue(result[0]["ok"])
@@ -367,10 +369,17 @@ class OpenListSyncTests(unittest.TestCase):
             },
         ):
             get_settings.cache_clear()
-            with patch("app.services.openlist_sync.sync_tracking_files", return_value={"ok": True, "copied": 1, "skipped": 0}) as sync_files:
+            with (
+                patch("app.services.openlist_sync.sync_tracking_files", return_value={"ok": True, "copied": 1, "skipped": 0, "target_dir": "/115/tv/Show"}) as sync_files,
+                patch("app.services.openlist_sync._wait_for_openlist_p115_landing") as wait_for_landing,
+                patch("app.services.openlist_sync.run_post_transfer_pipeline") as pipeline,
+            ):
                 result = sync_transfer_outputs("qas", "/strm/tv/Show", ["Show.S01E01.mkv"])
 
         self.assertEqual(1, len(result))
+        self.assertTrue(result[0]["ok"])
+        wait_for_landing.assert_not_called()
+        pipeline.assert_not_called()
         sync_files.assert_called_once_with(
             {"provider": "qas", "save_path": "/strm/tv/Show", "tmdb_id": None, "media_type": "", "season_number": None},
             "p115",

--- a/tests/test_openlist_sync.py
+++ b/tests/test_openlist_sync.py
@@ -322,6 +322,37 @@ class OpenListSyncTests(unittest.TestCase):
             ).fetchone()
         self.assertEqual(("openlist", "done", "openlist_sync_done", "/strm/tv/Show"), tuple(job))
 
+    def test_auto_transfer_sync_waits_for_native_115_before_post_processing(self):
+        landed = [{"file_id": "115-1", "parent_id": "dir-1", "file_name": "Movie.mkv", "path": "/media/Movie.mkv", "size": 10}]
+        with patch.dict(
+            os.environ,
+            {
+                "OPENLIST_ENABLED": "true",
+                "OPENLIST_AUTO_SYNC": "true",
+                "OPENLIST_QAS_LIBRARY_PATH": "/quark",
+                "OPENLIST_P115_LIBRARY_PATH": "/115",
+                "QAS_SAVE_PATH": "/strm",
+                "P115_ROOT_PATH": "/media",
+                "ENABLED_CLOUD_PROVIDERS": "qas,p115",
+            },
+        ):
+            get_settings.cache_clear()
+            with (
+                patch("app.services.openlist_sync.sync_tracking_files", return_value={"ok": True, "copied": 1, "skipped": 0, "target_dir": "/115/Movie"}),
+                patch("app.services.openlist_sync._wait_for_openlist_p115_landing", return_value=("/media/Movie", landed)) as wait_for_landing,
+                patch("app.services.openlist_sync.run_post_transfer_pipeline", return_value=True) as pipeline,
+                patch("app.services.openlist_sync._openlist_post_processing_summary", return_value="STRM 已生成"),
+            ):
+                result = sync_transfer_outputs("qas", "/strm/Movie", ["Movie.mkv"], display_title="Movie")
+
+        self.assertTrue(result[0]["ok"])
+        self.assertEqual(1, result[0]["landed"])
+        wait_for_landing.assert_called_once()
+        pipeline.assert_called_once_with(
+            result[0]["job_id"], provider="p115", title="Movie", openlist_message="115 已精确确认 1 个媒体文件落盘",
+            target_path="/media/Movie", target_files=landed,
+        )
+
     def test_auto_sync_uses_configured_opposite_mount_without_native_provider_enablement(self):
         init_db()
         with patch.dict(

--- a/tests/test_openlist_tasks.py
+++ b/tests/test_openlist_tasks.py
@@ -1,6 +1,7 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+from app.api.openlist import clear_finished_openlist_copy_tasks
 from app.clients.openlist import OpenListClient
 
 
@@ -32,6 +33,21 @@ class OpenListTaskTests(unittest.TestCase):
         client._get = Mock(side_effect=lambda path, **_kwargs: {"code": 200, "data": [{"id": "a", "progress": 150}, {"id": "b", "progress": "invalid"}]} if path.endswith("undone") else {"code": 200, "data": []})
         tasks = client.copy_tasks()
         self.assertEqual([100.0, 0.0], [task["progress"] for task in tasks])
+
+    def test_clear_finished_copy_tasks_uses_openlist_clear_done_endpoint(self):
+        client = object.__new__(OpenListClient)
+        client._post = Mock(return_value={"code": 200})
+        client.clear_finished_copy_tasks()
+        client._post.assert_called_once_with("/api/task/copy/clear_done", {})
+
+    @patch("app.api.openlist.OpenListClient")
+    @patch("app.api.openlist.get_settings")
+    def test_clear_finished_copy_tasks_api_delegates_to_openlist(self, settings, client_class):
+        settings.return_value.openlist_enabled = True
+        settings.return_value.openlist_token = "token"
+        result = clear_finished_openlist_copy_tasks()
+        self.assertTrue(result["ok"])
+        client_class.return_value.clear_finished_copy_tasks.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/test_strm_reconciler.py
+++ b/tests/test_strm_reconciler.py
@@ -133,6 +133,21 @@ class StrmReconcilerTests(unittest.TestCase):
         from app.services.media_assets import get_asset
         self.assertEqual("needs_review", get_asset(second["id"])["status"])
 
+    def test_removed_path_can_be_reused_by_a_new_remote_asset(self):
+        original = self._asset(file_id="old")
+        reconcile_strm(output_root=str(self.output), playback_base_url="http://127.0.0.1:8000")
+        mark_asset_deleted(original["id"])
+        reconcile_strm(output_root=str(self.output), playback_base_url="http://127.0.0.1:8000", allow_removal=True)
+        reconcile_strm(output_root=str(self.output), playback_base_url="http://127.0.0.1:8000", allow_removal=True)
+        replacement = self._asset(file_id="new")
+
+        result = reconcile_strm(output_root=str(self.output), playback_base_url="http://127.0.0.1:8000")
+
+        self.assertEqual(1, result.created)
+        entries = list_strm_entries()
+        self.assertEqual([replacement["id"]], [entry["asset_id"] for entry in entries])
+        self.assertTrue((self.output / "Movie.strm").is_file())
+
     def test_same_filename_in_different_media_directories_keeps_both_strm_files(self):
         register_asset(AssetInput(provider="p115", file_id="show-a", name="Episode 01.mkv", relative_path="Show A/Season 1/Episode 01.mkv", size=100, status="ready"))
         register_asset(AssetInput(provider="p115", file_id="show-b", name="Episode 01.mkv", relative_path="Show B/Season 1/Episode 01.mkv", size=100, status="ready"))


### PR DESCRIPTION
## Module scope

- Primary module: transfer
- Changed modules: openlist, strm, activity
- Shared/Core changed: No
- Cross-module reason (if applicable): OpenList copy completion must hand an exact, natively verified 115 file identity to the existing STRM post-transfer contract; Activity exposes OpenList's public task cleanup API.

## Compatibility

- Behavior changed: Yes — OpenList-to-115 jobs wait for native 115 landing before STRM post-processing, stale removed STRM path owners no longer block legitimate replacement assets, and clearing logs clears finished OpenList copy tasks.
- Database changed: No schema or migration changes; only stale rows already marked `removed` are retired when the same path is reused.
- Config or environment variables changed: No
- API contract changed: Yes — additive authenticated `POST /api/openlist/tasks/clear-finished`; existing endpoints are unchanged.
- Backward compatibility: Existing configuration, database schema, task reads, transfer callers, STRM safety checks, and API URLs remain compatible. Active path owners still become review conflicts rather than being overwritten.

## Proof

- Tests run: `PYTHONPATH=backend python -m unittest discover -s tests` (890 passed); focused OpenList/STRM/post-transfer suite (60 passed); `npm --prefix frontend run build`; `git diff --check`.
- Local browser acceptance (when user-visible): Not run; the persistent local sandbox was not active. Acceptance target is clearing finished OpenList tasks from Run Logs and rerunning an incremental STRM scan for a reused path.
- Known risks or follow-ups: Real OpenList and 115 were not contacted from the isolated workspace. No enterprise-WeChat simulator routes, UI, styles, or tests are included.
